### PR TITLE
feat: mkdir target directory if it doesn't exist on exporting

### DIFF
--- a/pkg/ormb/ormb.go
+++ b/pkg/ormb/ormb.go
@@ -1,6 +1,7 @@
 package ormb
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/kleveross/ormb/pkg/exporter"
@@ -76,6 +77,11 @@ func (o ORMB) Tag(refStr, targetStr string) error {
 
 func (o ORMB) Export(refStr, dst string) error {
 	path, err := filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

 For convenience, create the target directory when export
- `os.MkdirAll` will do nothing if the directory already exists
- The permission bits perm are used before `umask`

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #146 

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @simon-cj 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
