### PR TITLE
feat(config): unify cache directory to save in $HOME/.ormb

### DIFF
--- a/cmd/ormb/cmd/root.go
+++ b/cmd/ormb/cmd/root.go
@@ -89,10 +89,8 @@ func initConfig() {
 		viper.AddConfigPath(ormbHome)
 
 		viper.SetConfigName("config")
-		rootPath, err := filepath.Abs(viper.GetString("rootPath"))
-		if err != nil {
-			logrus.WithField("error", err).Panicln("Failed to get `rootPath` env")
-		}
+		rootPath := viper.GetString("rootPath")
+
 		if rootPath == "" {
 			viper.SetDefault("rootPath", ormbHome)
 		}


### PR DESCRIPTION
When the config.yaml does not exists ormb will save `config.json` and cache in working directory, which is not consistent.

As Ormb desribes in PersistentFlags the default config path is `$HOME/.ormb/config.yaml`

```
rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.ormb/config.yaml)")
```

Maybe we can set `rootPath` default to `$HOME/.ormb` as we already do this  in function `initConfig`


**Does this PR introduce a user-facing change?:**
```
Set default rootPath to $HOME/.ormb
```

Signed-off-by: 屈骏 <qujun@tiduyun.com>