### PR TITLE
Fix python sdk export command

### DIFF
--- a/extern-sdk/python/ormb/api.py
+++ b/extern-sdk/python/ormb/api.py
@@ -24,7 +24,7 @@ def pull(ref: str):
 
 
 def export(ref: str, dst: str):
-    ex = Popen([join(BIN_PATH, "ormb"), "export", ref, dst])
+    ex = Popen([join(BIN_PATH, "ormb"), "export", ref, "-d", dst])
     status = ex.wait()
     return status
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds the destination flag `-d` to the `export` command so that the passed value isn't ignored

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #186

**Special notes for your reviewer**:

/cc @gaocegege 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
