### PR TITLE
Install Darwin x86-64 binaries when i386 do not exist

### DIFF
--- a/extern-sdk/python/git_release.py
+++ b/extern-sdk/python/git_release.py
@@ -41,6 +41,9 @@ def download():
     for asset in json_info["assets"]:
         if asset_name in asset["browser_download_url"]:
             asset_url = asset["url"]
+        # temporary fix for non existing Darwin i386 binaries
+        elif "Darwin_i386" in asset_name and os_name in asset["browser_download_url"]:
+            asset_url = asset["url"]
 
     # download the url contents in binary format
     headers = {'Accept': 'application/octet-stream'}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area cli

**What this PR does / why we need it**:

Install Darwin x86-64 binaries when i386 do not exist

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Reference to #181

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
