### PR TITLE
[python-sdk] Remove requests dependency

### DIFF
--- a/extern-sdk/python/git_release.py
+++ b/extern-sdk/python/git_release.py
@@ -1,9 +1,9 @@
 import json
-import requests
+import os
 import platform
 import sys
 import tarfile
-import os
+import urllib.request
 
 
 REPOS = "kleveross/ormb"
@@ -21,12 +21,12 @@ def untar(fname, dirs):
 
 def download():
     url = 'https://api.github.com/repos/%s/releases/%s' % (REPOS, VERSION)
-    r = requests.get(url)
+    r = urllib.request.urlopen(url)
 
-    if r.status_code != 200:
-        raise Exception("get assets info err, ret code: %s" % r.status_code)
+    if r.status != 200:
+        raise Exception("get assets info err, ret code: %s" % r.status)
 
-    json_info = json.loads(r.text)
+    json_info = json.loads(r.read())
 
     cur_version = json_info["tag_name"][1:]
 
@@ -47,15 +47,15 @@ def download():
 
     # download the url contents in binary format
     headers = {'Accept': 'application/octet-stream'}
-    r = requests.get(asset_url, headers=headers)
+    req = urllib.request.Request(asset_url, headers=headers)
+    r = urllib.request.urlopen(req)
 
     # open method to open a file on your system and write the contents
     with open(asset_name, "wb") as code:
-        code.write(r.content)
+        code.write(r.read())
 
     if not os.path.exists(BIN_PATH):
         os.mkdir(BIN_PATH)
     untar(asset_name, BIN_PATH)
 
     os.remove(asset_name)
-

--- a/extern-sdk/python/setup.py
+++ b/extern-sdk/python/setup.py
@@ -30,9 +30,6 @@ setup(
     maintainer="gaocegege, ZhuYuJin",
     description="ormb warehouse",
     python_requires=">=3.6",
-    install_requires=[
-        "requests"
-    ],
     packages=find_packages(include=("ormb", "ormb.*")),
     package_data={'ormb': ['bin/*']},
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind dependency

**What this PR does / why we need it**:

It replaces `requests` dependency with `urllib.request` from the python standard library in `git_release.py` (called by `setup.py`) in the python sdk. We need to get rid of the `requests` dependency to fix the `setup.py` bug that calls the `requests` package before installing it.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #195

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
